### PR TITLE
fix: add link underline on hover od-90

### DIFF
--- a/src/client/public/css/components/link.css
+++ b/src/client/public/css/components/link.css
@@ -2,3 +2,7 @@
 	color: var(--color-blue);
 	text-decoration: none;
 }
+
+.link:hover {
+	text-decoration: underline;
+}


### PR DESCRIPTION
![Знімок екрана 2024-03-29 194136](https://github.com/GEOFARL/online-dictionary/assets/116633872/dcdabab8-c5e5-4244-a829-5f1eb5fb7e6e)
